### PR TITLE
Stub out the idea of synced state between main and worker threads

### DIFF
--- a/src/implementations/worker/_internal.ts
+++ b/src/implementations/worker/_internal.ts
@@ -1,0 +1,5 @@
+export const isWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
+
+export type Disposable<T> = T & {
+    cleanup();
+};

--- a/src/implementations/worker/primitive.ts
+++ b/src/implementations/worker/primitive.ts
@@ -1,0 +1,71 @@
+import { Cleanup } from "nasturtium/manifold";
+import { createPrimitive, PrimitiveState } from "nasturtium/types/primitive";
+import { isWorker, type Disposable } from "./_internal";
+
+export function syncPrimitive<T>(name: string): Promise<Disposable<PrimitiveState<T>>>
+export function syncPrimitive<T>(name: string, state: PrimitiveState<T>, worker: Worker): Cleanup
+export function syncPrimitive<T>(name: string, state?: PrimitiveState<T>, worker?: Worker) {
+    if(isWorker && state) {
+        throw new Error("Primitives can only be synced from main thread to workers!");
+    }
+
+    const messageKey = `$state:primitive:${name}`;
+    let cached: T, timeout, next;
+
+    function onReceiveMessage(e: MessageEvent) {
+        if(typeof e.data !== "object") return;
+        if(!Object.hasOwn(e.data, messageKey)) return;
+
+        if(next) {
+            return next(e.data[messageKey], e);
+        }
+
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        state!.value = (cached = e.data[messageKey]);
+    }
+
+    if(state && worker) {
+        cached = state.get();
+        worker.addEventListener("message", onReceiveMessage);
+
+        const cleanup = state.observe(value => {
+            if(value === cached) return;
+
+            cached = value;
+            worker.postMessage({ [messageKey]: value });
+        });
+
+        worker.postMessage({
+            [messageKey]: { name, initialValue: cached }
+        });
+
+        return cleanup;
+    }
+
+    addEventListener("message", onReceiveMessage);
+
+    if(!worker) {
+        return new Promise((resolve, reject) => {
+            timeout = setTimeout(() => reject("Could not sync primitive"), 5000);
+            next = payload => {
+                if(payload.name !== name) return;
+                next = null;
+
+                clearTimeout(timeout);
+                state = createPrimitive(payload.initialValue);
+
+                const cleanup = state.observe(value => {
+                    if(value === cached) return;
+
+                    cached = value;
+                    postMessage({ [messageKey]: value });
+                });
+
+                state["cleanup"] = cleanup;
+
+                return resolve(state);
+            };
+        });
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "lib": [ "ES2022", "DOM", "DOM.Iterable" ],
+        "lib": [ "ES2022", "DOM", "DOM.Iterable", "WebWorker" ],
         "module": "ES2022",
         /* Bundler mode */
         "moduleResolution": "node",


### PR DESCRIPTION
## Description

Worker threads are a common feature in modern JS, and being able to sync stateful data between the two would be really cool. So I've stubbed out a concept on how to achieve that, via `syncPrimitive()`.

## The Idea

State is named and exported/imported between threads. Each state type gets a sync function, which has a different shape depending on if you are publishing or subscribing a piece of state. The worker copy of the state is fully functional, so any stateful changes made will be reflected on the other end. Below is an example for primitives.

### Main Thread

On the main, thread, you call a sync function with a name, state, and worker. It will return a function that you can optionally call to decouple (dubbed "desync") the state from the two. It is recommended to do this whenever you are no longer using the worker thread.

```ts
const testPrimitive = createPrimitive(false);
const worker = new Worker("./worker.js");
const desync = syncPrimitive("test", testPrimitive, worker);
```

### Worker Thread

From the worker side, you can "import" a primitive by name. It is important to note that imports must happen in the same order as they are "sent", I am working on a way around this, but for now it has to be ordered.

```ts
const primitive = await syncPrimitive<boolean>("test");
primitive.observe(value => console.log("Worker value:", value));
```